### PR TITLE
Added Functions to Multiple Park Access Points

### DIFF
--- a/R/park-access-ethnicity.R
+++ b/R/park-access-ethnicity.R
@@ -3,6 +3,8 @@ library("dplyr")
 library("ggplot2")
 
 park_access_by_eth <- read_excel("../output/park_demographics.xlsx") %>%
+  # White pop only has greatest access by area when including Sutton Park
+  # filter(Park_Name != "Sutton Park") %>%
   select(
     `Asian, Asian British or Asian Welsh`,
     `Black, Black British, Black Welsh, Caribbean or African`,
@@ -68,7 +70,7 @@ count_plt <- ggplot(
     expand  = c(0,0)
     )
 count_plt
-ggsave("../output/park_count_access.png", plot = count_plt, 
+ggsave("../output/figures/park_count_access.png", plot = count_plt, 
        width = 6, height = 4, dpi = 300)
 
 area_plt <- ggplot(
@@ -86,5 +88,5 @@ area_plt <- ggplot(
     expand  = c(0,0)
   )
 area_plt
-ggsave("../output/park_area_access.png", plot = area_plt, 
+ggsave("../output/figures/park_area_access.png", plot = area_plt, 
        width = 6, height = 4, dpi = 300)

--- a/R/park-demographics.R
+++ b/R/park-demographics.R
@@ -26,7 +26,7 @@ map <- plot_empty_map(
 
 map <- add_radii(
   map,
-  park_postcodes,
+  park_coords,
   radii = dist_10_min_walk_km,
   alpha = 0.1,
   color = "darkgreen"
@@ -34,7 +34,7 @@ map <- add_radii(
 
 map <- add_points(
   map,
-  park_postcodes,
+  park_coords,
   color = "black"
 )
 
@@ -71,7 +71,7 @@ map
 
 park_info <- get_park_info(
   park_coords,
-  index = example_index,
+  park_name = "Sutton Park",
   dist_10_min_walk_km*1000)
 
 print(park_info)

--- a/R/park-demographics.R
+++ b/R/park-demographics.R
@@ -19,6 +19,7 @@ park_coords <- park_postcodes %>%
     Postcode = gsub("\\s+", " ", Postcode)
   ) %>%
   left_join(
+    # Loaded with functions.R
     wm_postcodes,
     by = join_by("Postcode")
   )
@@ -54,6 +55,7 @@ map <- add_points(
 
 map
 
+save_map(map, "../output/figures/park_spheres.png")
 ############################################################################
 #      Estimate percentage LSOA coverage from each park  (Example)         #
 ############################################################################
@@ -66,7 +68,7 @@ LSOA_coverage <- get_LSOA_coverage(
   )
 
 # Plot postcode coverage percentage
-plot_map(
+map <- plot_map(
   LSOA_coverage,
   value_header = "overlap_perc",
   map_type = "LSOA21",
@@ -142,9 +144,13 @@ pop_plt <- ggplot(all_park_info,
     y = "Number of Parks",
     x = "Estimated Population in 10-Minute Walking Distance"
   ) +
-  theme_bw()
+  theme_bw() +
+  scale_y_continuous(
+    limits = c(0, 35),
+    expand = c(0, 0)
+  )
 pop_plt
-ggsave("../output/pop_dist.png", plot = pop_plt,
+ggsave("../output/figures/pop_dist.png", plot = pop_plt,
        width = 5, height = 3, dpi = 300)
 
 # IMD distribution
@@ -162,8 +168,13 @@ pop_plt <- ggplot(all_park_info,
     breaks = 1:10,
     labels = c("1\n(Most Deprived)", "2", "3", "4", "5",
                "6", "7", "8", "9", "10\n(Least Deprived)"),
-    limits = c(0.5,10.5)
+    limits = c(0.5,10.5),
+    expand  = c(0,0)
+  ) +
+  scale_y_continuous(
+    limits = c(0, 150),
+    expand = c(0, 0)
   )
 pop_plt
-ggsave("../output/imd_dist.png", plot = pop_plt,
+ggsave("../output/figures/imd_dist.png", plot = pop_plt,
        width = 5, height = 3, dpi = 300)

--- a/R/testing/multiple-access-points.R
+++ b/R/testing/multiple-access-points.R
@@ -1,0 +1,107 @@
+library(dplyr)
+library(readxl)
+library(writexl)
+library(tmap)
+
+############################################################################
+#  Create new data file with seperate park info and access point coords    #
+############################################################################
+
+park <- read_excel("../../data/PARKS-WHITE-BOOK-2021 - multi access.xlsx",
+                           sheet = "Park Info") %>%
+  mutate(
+    POSTCODE = gsub("\\s+", " ", POSTCODE)
+  ) 
+colnames(park) <- gsub("/", "", 
+                       stringr::str_to_title(colnames(park)))
+colnames(park) <- gsub("\\s{1,}", "_", 
+                       stringr::str_to_title(colnames(park)))
+
+wm_postcodes <- read.csv(
+  "../../data/West Midlands postcodes.csv"
+) %>%
+  mutate(
+    LSOA21 = LSOA21.Code,
+    IMD_rank = Index.of.Multiple.Deprivation
+  ) %>%
+  select(
+    Postcode, Longitude, Latitude
+  )
+
+# Assuming walking speed of 5 km/hr
+dist_10_min_walk_km = 10 * 5 / 60
+
+park_locs <- park %>% 
+  select(Site_Name, Postcode, Area_Acres, Square_Meters) %>%
+  left_join(
+    wm_postcodes,
+    by = join_by("Postcode")
+  ) %>%
+  arrange(desc(Area_Acres)) %>%
+  mutate(
+    crude_radius_km = sqrt(Square_Meters/pi)/1e3,
+    Multiple_Points = crude_radius_km > dist_10_min_walk_km / 4
+  ) %>%
+  select(
+    Site_Name, Postcode, Multiple_Points, Longitude, Latitude
+  )
+
+output_list <- list(
+  "Park Info" = park,
+  "Park Locations" = park_locs
+)
+
+
+# write_xlsx(output_list, "../../data/park_multi_access_info_2024_raw.xlsx")
+
+############################################################################
+#             Show multiple access points for Sutton Park                  #
+############################################################################
+
+park_coords <- read_excel(
+  "../../data/park_multi_access_info_2024.xlsx",
+  "Park Locations"
+)
+
+multi_site_parks <- park_coords %>%
+  filter(Access_Point == 2) %>%
+  pull(Site_Name)
+
+for (site_i in multi_site_parks) {
+  
+  park_i <- park_coords%>%
+    filter(Site_Name == site_i) %>%
+    select(-Postcode) %>%
+    rename(LONG = Longitude,
+           LAT = Latitude)
+  
+  map <- plot_empty_map(
+    area_name = "Birmingham",
+    const_lines = F,
+    const_names = F
+  )
+  
+  map <- add_radii(
+    map,
+    park_i,
+    radii = dist_10_min_walk_km,
+    alpha = 0.1,
+    color = "orange"
+  )
+  
+  map <- add_points(
+    map,
+    park_i,
+    color = "black",
+    size = 0.05
+  )
+  
+  map
+  
+  save_name <- paste0(
+    "../../output/figures/park-access-points/",
+    gsub("\\s{1,}", "_", tolower(site_i)),
+    ".html"
+  )
+  save_map(map, save_name)
+}

--- a/R/testing/multiple-access-points.R
+++ b/R/testing/multiple-access-points.R
@@ -105,12 +105,3 @@ for (site_i in multi_site_parks) {
   )
   save_map(map, save_name)
 }
-
-source("functions.R")
-get_park_info(
-  park_coords,
-  "Sutton Park",
-  dist_10_min_walk_km * 1000
-)
-
-

--- a/R/testing/multiple-access-points.R
+++ b/R/testing/multiple-access-points.R
@@ -105,3 +105,12 @@ for (site_i in multi_site_parks) {
   )
   save_map(map, save_name)
 }
+
+source("functions.R")
+get_park_info(
+  park_coords,
+  "Sutton Park",
+  dist_10_min_walk_km * 1000
+)
+
+


### PR DESCRIPTION
Separated the park info sheet into two parts:
- Sheet with the name, official postcode, sizes, other location info, etc
- Sheet with coordinates for all entrances for each park

Second sheet highlights all parks for which the radius of the park is more than a 2.5 minute walk (1/4 of the threshold distance for accessibility). This is calculated assuming a circular park shape and a 5 km/hr walking speed. These parks have been highlighted as they are likely to have the largest changes in estimated population demographics when adding additional access points. 

An example map showing how the multiple access points are use for Sutton Park (the largest park in Birmingham) is shown below.

![sutton-park-example](https://github.com/user-attachments/assets/7e9d6a5f-fc10-4bdb-a768-3f072f05f22e)
